### PR TITLE
Added outputStyle argument in makeRenderOpts to allow specification of outputStyle

### DIFF
--- a/tasks/libsass.js
+++ b/tasks/libsass.js
@@ -36,6 +36,7 @@ module.exports = function(grunt) {
         return {
             file: file.src,
             outFile: file.dest,
+            outputStyle: file.__libsassOptions.outputStyle,
             includePaths: file.__libsassOptions.loadPath,
             sourceMap: file.__libsassOptions.sourcemap,
             success: makeSuccessFn(file, deferred),


### PR DESCRIPTION
Diggin' the grunt plugin, however, it lacked support of parsing outputStyle and handing it to libsass.