### PR TITLE
Update Readme - Where syntax needs to be corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ grunt.initConfig({
       loadPath: ['my/load/path'],
       sourcemap: true
     },
-    files: {[
+    files: [{
         {
             expand: true,
             cwd: 'my/src/dir',
@@ -93,7 +93,7 @@ grunt.initConfig({
             dest: 'dist',
             ext: '.css'
         }
-    ]},
+    }],
   }
 });
 ```


### PR DESCRIPTION
In Libsass, 'files' expecting a array of object. Corrected the same in order to get the proper syntax.